### PR TITLE
fix: hide browser native X in favor of custom X

### DIFF
--- a/frontend/src/lib/components/ui/SearchInput.svelte
+++ b/frontend/src/lib/components/ui/SearchInput.svelte
@@ -62,3 +62,11 @@
 		</button>
 	{/if}
 </label>
+
+<style>
+	input[type='search']::-webkit-search-cancel-button,
+	input[type='search']::-webkit-search-decoration {
+		-webkit-appearance: none;
+		appearance: none;
+	}
+</style>


### PR DESCRIPTION
<img width="852" height="403" alt="image@2x" src="https://github.com/user-attachments/assets/3d8f1b6e-fc51-44e7-9d67-39bcab9b2f67" />

doesnt show two crosses in the search bar anymore